### PR TITLE
Update Numpy and Cython for Python 3.10 and 3.11 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,15 +101,15 @@ jobs:
             os: ubuntu-latest
             pyver: cp310-cp310
             piparch: manylinux2014_x86_64
-            numpy: numpy==1.22.0
-            cython: Cython==0.29.23
+            numpy: numpy==2.0.1
+            cython: Cython==3.0.10
 
           - name: linux 3.11 amd64
             os: ubuntu-latest
             pyver: cp311-cp311
             piparch: manylinux2014_x86_64
-            numpy: numpy==1.23.5
-            cython: Cython==0.29.35
+            numpy: numpy==2.0.1
+            cython: Cython==3.0.10
 
           - name: linux 3.12 amd64
             os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "setuptools_dso>=2.11a2; python_version>='3.12'",
     "wheel",
     "numpy",
-    "numpy>=2.0.1; python_version>='3.10'",
+    "numpy>=2.0.1,<2.3; python_version>='3.10'",
     "Cython>=0.20",
     "epicscorelibs==7.0.7.99.0.2; python_version<='3.11'",
     "epicscorelibs>=7.0.7.99.1.1a2; python_version>='3.12'",

--- a/src/p4p/version.py
+++ b/src/p4p/version.py
@@ -67,4 +67,4 @@ class Version(object):
     def __gt__(self, o):
         return self._cmp(o)>0
 
-version = Version('4.2.0a1')
+version = Version('4.2.0a2')


### PR DESCRIPTION
This PR sets the wheel builds for Python 3.10 and 3.11 to use Numpy 2.0.1