### PR TITLE
add support to initialise NTEnum like NTScalar

### DIFF
--- a/src/p4p/nt/enum.py
+++ b/src/p4p/nt/enum.py
@@ -67,8 +67,12 @@ class NTEnum(NTBase):
             V['value.choices'] = choices
 
         if isinstance(value, dict):
-            # assume dict of index and choices list
-            V.value = value
+            if value.keys() == set(['index', 'choices']):
+                # assume dict for Value.value (index and choices list)
+                V.value = value
+            else:
+                # assume dict for Value
+                V = Value(self.type, value)
             self._choices = V['value.choices']
         else:
             # index or string


### PR DESCRIPTION
When initialising an NTEnum with a python dict, it is assumed that the dict is meant for the Value.value and contains `index` and `choices` keys for the value.  This PR adds ability to initialise value and any other fields of the NTEnum, similar to initialising an NTScalar.

```
pv = SharedPV(
    nt=NTEnum(display=True),
    initial={
        'value.index': 0,
        'value.choices': ['STOP', 'START', 'STANDBY'],
        'display.description': "Pump on/off control word."
    }
)
```