### PR TITLE
Building P4P against PVXS+TLS

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -32,6 +32,9 @@ CROSS_COMPILER_TARGET_ARCHS =
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
+# Uncomment the appropriate line or include in your private $(TOP)/../CONFIG_SITE.local
+# PVXS_WITH_TLS = YES
+
 -include $(TOP)/configure/CONFIG_SITE.local
 
 -include $(TOP)/../CONFIG_SITE.local

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -32,8 +32,12 @@ CROSS_COMPILER_TARGET_ARCHS =
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
-# Uncomment the appropriate line or include in your private $(TOP)/../CONFIG_SITE.local
-# PVXS_WITH_TLS = YES
+# ======================================================
+# To enable TLS uncomment the appropriate line or 
+# include in your private $(TOP)/../CONFIG_SITE.local
+# ======================================================
+# USR_CPPFLAGS += -DPVXS_ENABLE_OPENSSL
+# P4P_WITH_TLS = YES
 
 -include $(TOP)/configure/CONFIG_SITE.local
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,26 @@ include $(TOP)/configure/CONFIG_PY
 # return c++ types.
 USR_CPPFLAGS += -D__PYX_EXTERN_C=extern
 
+USR_INCLUDES += -I$(OPENSSL_INCLUDE)
+
+# ======================================================
+# PATH TO "NON EPICS" EXTERNAL PACKAGES: USER LIBRARIES
+# ======================================================
+ssl_DIR = $(OPENSSL_LIB)
+crypto_DIR = $(OPENSSL_LIB)
+# ======================================================
+
+# ======================================================
+# LINK "NON EPICS" EXTERNAL PACKAGE LIBRARIES Statically
+# ======================================================
+#USR_LIBS += ssl crypto
+
+# ========================================================
+# LINK "NON EPICS" EXTERNAL PACKAGE LIBRARIES Dynamically
+# ========================================================
+LIB_SYS_LIBS += ssl crypto event event_openssl event_pthreads
+# =======================================================
+
 # place .so in subdirectory
 INSTALL_SHRLIB = $(PY_INSTALL_DIR)/p4p
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,21 +8,14 @@ include $(TOP)/configure/CONFIG_PY
 USR_CPPFLAGS += -D__PYX_EXTERN_C=extern
 
 
-
-ifeq ($(PVXS_WITH_TLS),YES)
-     USR_INCLUDES += -I$(OPENSSL_INCLUDE)
-
-    # ======================================================
-    # PATH TO "NON EPICS" EXTERNAL PACKAGES: USER LIBRARIES
-    # ======================================================
-    ssl_DIR = $(OPENSSL_LIB)
-    crypto_DIR = $(OPENSSL_LIB)
-   # ======================================================
-
-   # ========================================================
+ifeq ($(P4P_WITH_TLS),YES)
+   # ==========================================================
    # LINK "NON EPICS" EXTERNAL PACKAGE LIBRARIES Dynamically
-   # ========================================================
-   LIB_SYS_LIBS += ssl crypto event event_openssl event_pthreads
+   # ssl crypto event event_openssl event_pthreads are derived
+   # from the PVXS module
+   # ==========================================================
+   LIB_SYS_LIBS += $(LIBEVENT_SYS_LIBS)
+   LIB_SYS_LIBS += $(LIBEVENT_BUNDLE_LIBS) 
    # =======================================================
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,28 +9,22 @@ USR_CPPFLAGS += -D__PYX_EXTERN_C=extern
 
 
 
-ifeq ($PVXS_WITH_TLS),YES)
-USR_INCLUDES += -I$(OPENSSL_INCLUDE)
+ifeq ($(PVXS_WITH_TLS),YES)
+     USR_INCLUDES += -I$(OPENSSL_INCLUDE)
 
-# ======================================================
-# PATH TO "NON EPICS" EXTERNAL PACKAGES: USER LIBRARIES
-# ======================================================
-ssl_DIR = $(OPENSSL_LIB)
-crypto_DIR = $(OPENSSL_LIB)
-# ======================================================
+    # ======================================================
+    # PATH TO "NON EPICS" EXTERNAL PACKAGES: USER LIBRARIES
+    # ======================================================
+    ssl_DIR = $(OPENSSL_LIB)
+    crypto_DIR = $(OPENSSL_LIB)
+   # ======================================================
 
-# ======================================================
-# LINK "NON EPICS" EXTERNAL PACKAGE LIBRARIES Statically
-# ======================================================
-#USR_LIBS += ssl crypto
-
-# ========================================================
-# LINK "NON EPICS" EXTERNAL PACKAGE LIBRARIES Dynamically
-# ========================================================
-LIB_SYS_LIBS += ssl crypto event event_openssl event_pthreads
-# =======================================================
-endif    # PVXS_WITH_TLS 
-
+   # ========================================================
+   # LINK "NON EPICS" EXTERNAL PACKAGE LIBRARIES Dynamically
+   # ========================================================
+   LIB_SYS_LIBS += ssl crypto event event_openssl event_pthreads
+   # =======================================================
+endif
 
 # place .so in subdirectory
 INSTALL_SHRLIB = $(PY_INSTALL_DIR)/p4p

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,9 @@ include $(TOP)/configure/CONFIG_PY
 # return c++ types.
 USR_CPPFLAGS += -D__PYX_EXTERN_C=extern
 
+
+
+ifeq ($PVXS_WITH_TLS),YES)
 USR_INCLUDES += -I$(OPENSSL_INCLUDE)
 
 # ======================================================
@@ -26,6 +29,8 @@ crypto_DIR = $(OPENSSL_LIB)
 # ========================================================
 LIB_SYS_LIBS += ssl crypto event event_openssl event_pthreads
 # =======================================================
+endif    # PVXS_WITH_TLS 
+
 
 # place .so in subdirectory
 INSTALL_SHRLIB = $(PY_INSTALL_DIR)/p4p


### PR DESCRIPTION
Changes made in order to compile P4P with the forked PVXS tls branch.

HOST OS: Rocky 9
Python ENV 3.10

Due to conflicts with openssl library provided by conda at run time I needed the following:
LD_PRELOAD=/usr/lib64/libssl.so:/usr/lib64/libcrypto.so LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH bin/rhel9-x86
_64/pvagw -h

Here is my CONFIG_SITE.local file for reference:

```
(p4p-build-env) ernesto@dev-epicsgw $ cat CONFIG_SITE.local
# Enable OpenSSL support
USR_CPPFLAGS += -DPVXS_ENABLE_OPENSSL

# CONDA ENV has openssl but version is older than the system library from Rocky 9, which is what PVXS used.
# CONDA_PREFIX=/sdf/sw/epics/package/anaconda/2024.10/envs/p4p-build-env

# ========================================================
# We will use openssl from the Rocky 9 Linux Distribution:
# This will make P4P consistent with PVXS when linking.
# ========================================================
OPENSSL_LIB=/usr/lib64
OPENSSL_INCLUDE=/usr/include/openssl

# =================================================
# Build P4P with TLS support.
# =================================================
PVXS_WITH_TLS = YES

# =============================
# Build Application Statically
# =============================
#SHARED_LIBRARIES=NO
#STATIC_BUILD=YES
(p4p-build-env) ernesto@dev-epicsgw $
```

md: edit to be less shouty