### PR TITLE
Upgrade Numpy versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
             os: ubuntu-latest
             pyver: cp39-cp39
             piparch: manylinux2010_x86_64
-            numpy: numpy==1.19.3
+            numpy: numpy==1.21.6 # Highest supported on this piparch
             cython: Cython==0.29.23
 
           - name: linux 3.10 amd64
@@ -108,14 +108,14 @@ jobs:
             os: ubuntu-latest
             pyver: cp311-cp311
             piparch: manylinux2014_x86_64
-            numpy: numpy==2.0.1
+            numpy: numpy==2.2.6 # Highest supported on this piparch
             cython: Cython==3.0.10
 
           - name: linux 3.12 amd64
             os: ubuntu-latest
             pyver: cp312-cp312
             piparch: manylinux2014_x86_64
-            numpy: numpy==2.0.1
+            numpy: numpy==2.2.6 # Highest supported on this piparch
             cython: Cython==3.0.10
             skip_cothread: yes
 
@@ -123,7 +123,7 @@ jobs:
             os: ubuntu-latest
             pyver: cp313-cp313
             piparch: manylinux2014_x86_64
-            numpy: numpy==2.1.0
+            numpy: numpy==2.2.6 # Highest supported on this piparch
             cython: Cython==3.0.10
             skip_cothread: yes
 
@@ -284,16 +284,16 @@ jobs:
             os: windows-latest
             python: "3.9"
             piparch: win_amd64
-            numpy: numpy==1.19.5
-            cython: Cython==0.29.23
+            numpy: numpy==2.0.2
+            cython: Cython==3.0.10
             skip_cothread: yes
 
           - name: win64 3.10
             os: windows-latest
             python: "3.10"
             piparch: win_amd64
-            numpy: numpy==1.21.3
-            cython: Cython==0.29.23
+            numpy: numpy==2.2.6
+            cython: Cython==3.0.10
             skip_cothread: yes
 
           - name: win64 3.11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,8 +284,8 @@ jobs:
             os: windows-latest
             python: "3.9"
             piparch: win_amd64
-            numpy: numpy==2.0.2
-            cython: Cython==3.0.10
+            numpy: numpy==1.19.5
+            cython: Cython==0.29.23
             skip_cothread: yes
 
           - name: win64 3.10


### PR DESCRIPTION
Upgrade Numpy versions to the highest supported version on each platform. Doing this should ensure maximum compatibility as wheels built against Numpy2 can support using Numpy1 at runtime.

In order to have compatibility between Numpy 1 and Numpy 2 builds, builds should all be done with Numpy 2. See [Numpy Docs here](https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice).

Note that Windows with Python 3.9 _should_ support Numpy 2.0 but does not due to [this numpy issue](https://github.com/numpy/numpy/issues/27224).